### PR TITLE
Improve handling of app menu updates

### DIFF
--- a/app/src/main/java/cu/axel/smartdock/adapters/AppAdapter.kt
+++ b/app/src/main/java/cu/axel/smartdock/adapters/AppAdapter.kt
@@ -104,11 +104,20 @@ class AppAdapter(
         this.apps = newApps
         this.allApps.clear()
         this.allApps.addAll(newApps)
-        notifyDataSetChanged()
+        // If a query is active, re-apply it
+        if (::query.isInitialized && query.isNotEmpty()) {
+            filter(query)
+        } else {
+            this.apps = newApps
+            notifyDataSetChanged()
+        }
     }
 
     fun filter(query: String) {
         val results = ArrayList<App>()
+        if (query.isEmpty()) {
+            this.query = ""
+        }
         if (query.length > 1) {
             if (query.matches("^[0-9]+(\\.[0-9]+)?[-+/*][0-9]+(\\.[0-9]+)?".toRegex())) {
                 results.add(

--- a/app/src/main/java/cu/axel/smartdock/services/DockService.kt
+++ b/app/src/main/java/cu/axel/smartdock/services/DockService.kt
@@ -1169,6 +1169,11 @@ class DockService : AccessibilityService(), OnSharedPreferenceChangeListener, On
 
     fun hideAppMenu() {
         searchEt.setText("")
+        // Reset filter
+        val adapter = appsGv.adapter
+        if (adapter is AppAdapter) {
+            adapter.filter("")
+        }
         windowManager.removeView(appMenu)
         appMenuVisible = false
     }


### PR DESCRIPTION
* Tries to prevents the scroll position from being reset by updating the app list instead of replacing the current AppAdapter
* Keeps the current search during app list updates active, and clears it on app menu exit